### PR TITLE
feat: add ability to check both or either issue title or body

### DIFF
--- a/.github/workflows/assign.yml
+++ b/.github/workflows/assign.yml
@@ -14,4 +14,5 @@ jobs:
         with:
           keywords: '["assign","test"]'
           assignees: '["Naturalclar"]'
+          title-or-body: 'both'
           github-token: "${{ secrets.GITHUB_TOKEN }}"

--- a/.github/workflows/label.yml
+++ b/.github/workflows/label.yml
@@ -14,4 +14,5 @@ jobs:
         with:
           keywords: '["label", "test"]'
           labels: '["good first issue", "foo"]'
+          title-or-body: 'both'
           github-token: "${{ secrets.GITHUB_TOKEN }}"

--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ jobs:
         with:
           keywords: '["test"]'
           assignees: '["username"]'
+          title-or-body: 'both'
           github-token: "${{ secrets.GITHUB_TOKEN }}"
 ```
 
@@ -45,8 +46,13 @@ jobs:
         with:
           keywords: '["help", "wanted"]'
           labels: '["help wanted"]'
+          title-or-body: 'both'
           github-token: "${{ secrets.GITHUB_TOKEN }}"
 ```
+
+#### Title or Body
+
+Choose whether you want to check for a keyword match in the issue `title`, the issue `body`, or `both`.
 
 # Upgrading this package
 

--- a/__tests__/checkKeyword.test.ts
+++ b/__tests__/checkKeyword.test.ts
@@ -1,29 +1,21 @@
 import { checkKeyword } from "../src/checkKeyword";
 
 describe("checkKeyword", () => {
-  it("returns true if keyword is included in the title", () => {
-    const result = checkKeyword(["test"], { title: "test", body: "" });
-    expect(result).toBe(true);
-  });
-  it("returns true if keyword is included in the body", () => {
-    const result = checkKeyword(["test"], { title: "", body: "test" });
-    expect(result).toBe(true);
-  });
-  it("returns true if second keyword is included in title or body", () => {
-    const result = checkKeyword(["test", "bar"], { title: "bar", body: "" });
+  it("returns true if keyword is included in the issue content", () => {
+    const result = checkKeyword(["test"], "test");
     expect(result).toBe(true);
   });
   it("returns true for different casings in keyword", () => {
-    const result = checkKeyword(["test", "Bar"], { title: "bar", body: "" });
+    const result = checkKeyword(["test", "Bar"], "bar");
     expect(result).toBe(true);
   });
   it("returns true for different casings in content", () => {
-    const result = checkKeyword(["test", "bar"], { title: "Bar", body: "" });
+    const result = checkKeyword(["test", "bar"], "Bar");
     expect(result).toBe(true);
   });
 
   it("returns false if keyword is not included in title or body", () => {
-    const result = checkKeyword(["test"], { title: "", body: "" });
+    const result = checkKeyword(["test"], "");
     expect(result).toBe(false);
   });
 });

--- a/__tests__/getIssueContent.test.ts
+++ b/__tests__/getIssueContent.test.ts
@@ -2,5 +2,6 @@ import { getIssueContent } from "../src/getIssueContent";
 
 test("throws error if no issue provided", async () => {
   const input = "foo";
-  await expect(getIssueContent(input)).rejects.toThrow("No Issue Provided");
+  const titleOrBody = "both";
+  await expect(getIssueContent(input, titleOrBody)).rejects.toThrow("No Issue Provided");
 });

--- a/action.yml
+++ b/action.yml
@@ -11,6 +11,10 @@ inputs:
     description: "assignees to be assigned when keyword is found"
   labels:
     description: "labels to be set when keyword is found"
+  title-or-body:
+    description: "Whether to check the issue title, the issue body, or both for matching keywords"
+    required: false
+    default: "both"
 
 outputs:
   title:

--- a/src/checkKeyword.ts
+++ b/src/checkKeyword.ts
@@ -1,11 +1,10 @@
 export const checkKeyword = (
   keywords: string[],
-  content: { title: string; body: string }
+  content: string
 ): boolean => {
   return keywords.some(keyword => {
-    if (content.title.toLowerCase().includes(keyword.toLowerCase())) {
-      return true;
+    if (content.toLowerCase().includes(keyword.toLowerCase())) {
+      return content.toLowerCase().includes(keyword.toLowerCase());
     }
-    return content.body.toLowerCase().includes(keyword.toLowerCase());
   });
 };

--- a/src/getIssueContent.ts
+++ b/src/getIssueContent.ts
@@ -1,7 +1,7 @@
 import * as github from "@actions/github";
 import { getRepo, getIssueNumber } from "./github";
 
-export const getIssueContent = async (token: string) => {
+export const getIssueContent = async (token: string, titleOrBody) => {
   const octokit = new github.GitHub(token);
 
   const issue_number = getIssueNumber();
@@ -14,6 +14,13 @@ export const getIssueContent = async (token: string) => {
     ...getRepo(),
     issue_number
   });
-  const { title, body } = data;
-  return { title, body };
+
+  if (titleOrBody === 'title') {
+    return data.title;
+  } else if (titleOrBody === 'body') {
+    return data.body;
+  } else {
+    return `${data.title} ${data.body}`
+  }
+  
 };

--- a/src/index.ts
+++ b/src/index.ts
@@ -8,6 +8,7 @@ async function run() {
   try {
     core.setOutput("labeled", false.toString());
     core.setOutput("assigned", false.toString());
+    const titleOrBody: string = core.getInput("title-or-body");
     const keywords: string[] = JSON.parse(
       core.getInput("keywords", { required: true })
     );
@@ -15,7 +16,7 @@ async function run() {
     console.log(`keywords: ${keywords}`);
 
     const token = core.getInput("github-token");
-    const content = await getIssueContent(token);
+    const content = await getIssueContent(token, titleOrBody);
 
     const hasKeyword = checkKeyword(keywords, content);
     if (!hasKeyword) {


### PR DESCRIPTION
The title-or-body field takes either `title`, `body`, or `both` to determine which part of the issue to check for a matching keyword. By default it's set to `both`.
```yml
 - uses: Naturalclar/issue-action@v1.0.0
        with:
          keywords: '["help", "wanted"]'
          labels: '["help wanted"]'
          title-or-body: 'title'
          github-token: "${{ secrets.GITHUB_TOKEN }}"
```
```yml
 - uses: Naturalclar/issue-action@v1.0.0
        with:
          keywords: '["help", "wanted"]'
          labels: '["help wanted"]'
          title-or-body: 'body'
          github-token: "${{ secrets.GITHUB_TOKEN }}"
```
```yml
 - uses: Naturalclar/issue-action@v1.0.0
        with:
          keywords: '["help", "wanted"]'
          labels: '["help wanted"]'
          title-or-body: 'both'
          github-token: "${{ secrets.GITHUB_TOKEN }}"
```